### PR TITLE
fix(native): provide Windows HWND for media controls

### DIFF
--- a/crates/sparkplayer-native/src/media_controls.rs
+++ b/crates/sparkplayer-native/src/media_controls.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::Duration;
 
+use anyhow::{Context, Result};
 use souvlaki::{
     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
     SeekDirection,
@@ -58,12 +59,13 @@ pub struct MediaOs {
 }
 
 impl MediaOs {
-    pub fn new() -> Result<Self, souvlaki::Error> {
+    pub fn new() -> Result<Self> {
         let config = PlatformConfig {
             dbus_name: "sparkplayer",
             display_name: "SparkPlayer",
-            // Windows wants the console/window handle here; harmless elsewhere.
-            hwnd: None,
+            // Windows SMTC requires a window handle. For this terminal app, the
+            // console window is the closest owner; other platforms ignore it.
+            hwnd: platform_hwnd().context("Windows media controls require a window handle")?,
         };
         let mut controls = MediaControls::new(config)?;
 
@@ -178,4 +180,23 @@ impl MediaOs {
         fs::write(&path, bytes).ok()?;
         Some(format!("file://{}", path.to_string_lossy()))
     }
+}
+
+#[cfg(target_os = "windows")]
+fn platform_hwnd() -> Result<Option<*mut std::ffi::c_void>> {
+    #[link(name = "user32")]
+    unsafe extern "system" {
+        fn GetConsoleWindow() -> *mut std::ffi::c_void;
+    }
+
+    let hwnd = unsafe { GetConsoleWindow() };
+    if hwnd.is_null() {
+        anyhow::bail!("no console window handle is available");
+    }
+    Ok(Some(hwnd))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn platform_hwnd() -> Result<Option<*mut std::ffi::c_void>> {
+    Ok(None)
 }


### PR DESCRIPTION
I had to make the changes to avoid:
```
b557f\souvlaki-0.8.3\src\platform\windows\mod.rs:59:14:
Windows media controls require an HWND in MediaControlsOptions.
stack backtrace:
   0: std::panicking::panic_handler
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\std\src\panicking.rs:689
   1: core::panicking::panic_fmt
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\core\src\panicking.rs:80
   2: core::panicking::panic_display
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\core\src\panicking.rs:259
   3: core::option::expect_failed
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library\core\src\option.rs:2245
   4: enum2$<core::option::Option<ptr_mut$<core::ffi::c_void> > >::expect<ptr_mut$<core::ffi::c_vo                                              id> >
             at C:\Users\dhorner\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\                                              rust\library\core\src\option.rs:971
   5: souvlaki::platform::platform::MediaControls::new
             at C:\Users\dhorner\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\souvlaki-0.8                                              .3\src\platform\windows\mod.rs:59
   6: sparkplayer::media_controls::MediaOs::new
             at .\crates\sparkplayer-native\src\media_controls.rs:68
   7: sparkplayer::main
             at .\crates\sparkplayer-native\src\main.rs:204
   8: core::ops::function::FnOnce::call_once<enum2$<core::result::Result<tuple$<>,anyhow::Error> >                                               (*)(),tuple$<> >
             at C:\Users\dhorner\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\                                              rust\library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```