### PR TITLE
Bespoke integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3079,6 +3079,7 @@ dependencies = [
  "dirs",
  "ffmpeg-next",
  "image",
+ "libc",
  "lofty",
  "ratatui",
  "ratatui-image",
@@ -3088,6 +3089,7 @@ dependencies = [
  "sparkplayer-core",
  "symphonia 0.6.0",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sparkplayer-native/Cargo.toml
+++ b/crates/sparkplayer-native/Cargo.toml
@@ -29,6 +29,7 @@ ffmpeg-next = { version = "8.1", default-features = false, features = ["codec", 
 sdl2 = { version = "0.38", default-features = false }
 ab_glyph = "0.2"
 souvlaki = "0.8"
+libc = "0.2"
 
 [package.metadata.deb]
 name = "sparkplayer"
@@ -51,3 +52,5 @@ assets = [
 [package.metadata.wix]
 upgrade-guid = "8E83D6C4-5D8F-4F2E-9A19-1A8E5C2B3E4F"
 path-guid = "4B6A1C2E-9D7F-4E3A-8C5B-6F2D9E1A4B7C"
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Memory", "Win32_System_SystemServices"] }

--- a/crates/sparkplayer-native/src/audio.rs
+++ b/crates/sparkplayer-native/src/audio.rs
@@ -5,18 +5,20 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use ffmpeg_next as ffmpeg;
+use ffmpeg::ChannelLayout;
 use ffmpeg::format::sample::{Sample, Type as SampleType};
 use ffmpeg::media::Type as MediaType;
 use ffmpeg::software::resampling::Context as Resampler;
 use ffmpeg::util::frame::audio::Audio;
-use ffmpeg::ChannelLayout;
+use ffmpeg_next as ffmpeg;
 use rodio::source::Source;
 use rodio::{ChannelCount, Decoder, DeviceSinkBuilder, MixerDeviceSink, Player, SampleRate};
 
 use sparkplayer_core::backend::AudioBackend;
 use sparkplayer_core::library;
 use sparkplayer_core::{SampleBuffer, TrackRef};
+
+use crate::shared_audio::SharedAudioWriter;
 
 /// Audio source backed by an ffmpeg input. Used when playing video files
 /// (and also as a generic fallback for audio formats rodio's symphonia layer
@@ -140,17 +142,23 @@ impl FfmpegAudioSource {
 
     fn frame_disposition(&mut self, frame: &Audio) -> FrameDisposition {
         let Some(target) = self.pending_seek_secs else {
-            return FrameDisposition::Keep { skip_interleaved: 0 };
+            return FrameDisposition::Keep {
+                skip_interleaved: 0,
+            };
         };
         let Some(pts) = frame.pts() else {
             self.pending_seek_secs = None;
-            return FrameDisposition::Keep { skip_interleaved: 0 };
+            return FrameDisposition::Keep {
+                skip_interleaved: 0,
+            };
         };
         let tb_num = self.stream_time_base.numerator() as f64;
         let tb_den = self.stream_time_base.denominator() as f64;
         if tb_den == 0.0 {
             self.pending_seek_secs = None;
-            return FrameDisposition::Keep { skip_interleaved: 0 };
+            return FrameDisposition::Keep {
+                skip_interleaved: 0,
+            };
         }
         let frame_pts_secs = pts as f64 * tb_num / tb_den;
         let in_rate = frame.rate() as f64;
@@ -164,7 +172,9 @@ impl FfmpegAudioSource {
         }
         if frame_pts_secs >= target {
             self.pending_seek_secs = None;
-            return FrameDisposition::Keep { skip_interleaved: 0 };
+            return FrameDisposition::Keep {
+                skip_interleaved: 0,
+            };
         }
         let skip_per_channel = ((target - frame_pts_secs) * self.out_rate as f64).round() as i64;
         let skip_per_channel = skip_per_channel.max(0) as usize;
@@ -276,15 +286,25 @@ impl Source for FfmpegAudioSource {
 struct TapSource<S> {
     inner: S,
     tap: SampleBuffer,
+    shared_audio: Option<SharedAudioWriter>,
 }
 
 impl<S> TapSource<S>
 where
     S: Source<Item = f32>,
 {
-    fn new(inner: S, tap: SampleBuffer) -> Self {
-        tap.set_format(inner.channels().get(), inner.sample_rate().get());
-        Self { inner, tap }
+    fn new(inner: S, tap: SampleBuffer, shared_audio: Option<SharedAudioWriter>) -> Self {
+        let channels = inner.channels().get();
+        let sample_rate = inner.sample_rate().get();
+        tap.set_format(channels, sample_rate);
+        if let Some(shared) = shared_audio.as_ref() {
+            shared.set_format(channels, sample_rate);
+        }
+        Self {
+            inner,
+            tap,
+            shared_audio,
+        }
     }
 }
 
@@ -296,6 +316,9 @@ where
     fn next(&mut self) -> Option<f32> {
         let v = self.inner.next()?;
         self.tap.push(v);
+        if let Some(shared) = self.shared_audio.as_ref() {
+            shared.push_sample(v);
+        }
         Some(v)
     }
 }
@@ -323,7 +346,8 @@ where
 fn open_input(path: &Path) -> Result<ffmpeg::format::context::Input> {
     ffmpeg::init().ok();
     ffmpeg::util::log::set_level(ffmpeg::util::log::Level::Fatal);
-    ffmpeg::format::input(&path.to_path_buf()).with_context(|| format!("opening {}", path.display()))
+    ffmpeg::format::input(&path.to_path_buf())
+        .with_context(|| format!("opening {}", path.display()))
 }
 
 /// One selectable audio track inside a container, paired with the ffmpeg
@@ -413,6 +437,7 @@ pub struct AudioPlayer {
     pub tap: SampleBuffer,
     volume: f32,
     pub current_path: Option<PathBuf>,
+    shared_audio: Option<SharedAudioWriter>,
     /// Audio tracks of the current file (only populated for video containers).
     audio_tracks: Vec<AudioTrackInfo>,
     /// Index into `audio_tracks` of the track currently being decoded.
@@ -420,7 +445,7 @@ pub struct AudioPlayer {
 }
 
 impl AudioPlayer {
-    pub fn new() -> Result<Self> {
+    pub fn new(shared_audio: Option<SharedAudioWriter>) -> Result<Self> {
         let mut sink = DeviceSinkBuilder::open_default_sink()
             .context("failed to open default audio output")?;
         sink.log_on_drop(false);
@@ -432,6 +457,7 @@ impl AudioPlayer {
             tap,
             volume: 0.8,
             current_path: None,
+            shared_audio,
             audio_tracks: Vec::new(),
             active_audio_track: 0,
         })
@@ -451,6 +477,9 @@ impl AudioPlayer {
         self.player = Player::connect_new(self.sink.mixer());
         self.player.set_volume(self.volume);
         self.tap.reset();
+        if let Some(shared) = self.shared_audio.as_ref() {
+            shared.reset();
+        }
         self.current_path = Some(path.to_path_buf());
         self.audio_tracks.clear();
         self.active_audio_track = 0;
@@ -461,7 +490,7 @@ impl AudioPlayer {
             self.active_audio_track = default_idx;
             let source = self.open_video_audio(path)?;
             let total = source.total_duration();
-            let tapped = TapSource::new(source, self.tap.clone());
+            let tapped = TapSource::new(source, self.tap.clone(), self.shared_audio.clone());
             self.player.append(tapped);
             total
         } else {
@@ -469,7 +498,7 @@ impl AudioPlayer {
             let source = Decoder::new(BufReader::new(file))
                 .with_context(|| format!("decoding {}", path.display()))?;
             let total = source.total_duration();
-            let tapped = TapSource::new(source, self.tap.clone());
+            let tapped = TapSource::new(source, self.tap.clone(), self.shared_audio.clone());
             self.player.append(tapped);
             total
         };
@@ -489,7 +518,7 @@ impl AudioPlayer {
         if library::is_video_file(path) {
             let mut source = self.open_video_audio(path)?;
             source.seek(target)?;
-            let tapped = TapSource::new(source, self.tap.clone());
+            let tapped = TapSource::new(source, self.tap.clone(), self.shared_audio.clone());
             self.player.append(tapped);
         } else {
             let file = File::open(path)?;
@@ -499,13 +528,13 @@ impl AudioPlayer {
             // discards every sample from the start of the file, so the delay
             // grows the further into the track we seek.
             if source.try_seek(target).is_ok() {
-                let tapped = TapSource::new(source, self.tap.clone());
+                let tapped = TapSource::new(source, self.tap.clone(), self.shared_audio.clone());
                 self.player.append(tapped);
             } else {
                 let file = File::open(path)?;
                 let source = Decoder::new(BufReader::new(file))?;
                 let skipped = source.skip_duration(target);
-                let tapped = TapSource::new(skipped, self.tap.clone());
+                let tapped = TapSource::new(skipped, self.tap.clone(), self.shared_audio.clone());
                 self.player.append(tapped);
             }
         }
@@ -539,7 +568,7 @@ impl AudioPlayer {
 
         let mut source = self.open_video_audio(&path)?;
         source.seek(target)?;
-        let tapped = TapSource::new(source, self.tap.clone());
+        let tapped = TapSource::new(source, self.tap.clone(), self.shared_audio.clone());
         self.player.append(tapped);
 
         if was_paused {
@@ -592,6 +621,9 @@ impl AudioBackend for AudioPlayer {
     fn stop(&mut self) {
         self.player.stop();
         self.tap.reset();
+        if let Some(shared) = self.shared_audio.as_ref() {
+            shared.reset();
+        }
         self.current_path = None;
     }
 

--- a/crates/sparkplayer-native/src/main.rs
+++ b/crates/sparkplayer-native/src/main.rs
@@ -4,6 +4,7 @@ mod external_window;
 mod library_native;
 mod media_controls;
 mod metadata_native;
+mod shared_audio;
 mod subtitles_native;
 mod video;
 
@@ -28,10 +29,11 @@ use sparkplayer_core::{App, ui};
 
 use crate::audio::AudioPlayer;
 use crate::backends::{
-    build_picker, GraphicsChoice, NativeAlbumArt, NativeConfigStore, NativeVideoBackend,
+    GraphicsChoice, NativeAlbumArt, NativeConfigStore, NativeVideoBackend, build_picker,
 };
 use crate::library_native::NativeLibrary;
 use crate::media_controls::{MediaCommand, MediaOs};
+use crate::shared_audio::SharedAudioWriter;
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 enum GraphicsArg {
@@ -85,6 +87,10 @@ struct Cli {
     /// `English`).
     #[arg(long, value_name = "LANG")]
     subtitle_lang: Option<String>,
+
+    /// Shared-memory stream name used to publish decoded audio for Bespoke.
+    #[arg(long, value_name = "NAME", default_value = "/sparkplayer_audio", default_missing_value = "/sparkplayer_audio", num_args = 0..=1)]
+    bespoke_shm: String,
 }
 
 /// Translate a crossterm key into the platform-neutral [`CoreKeyEvent`] the
@@ -152,7 +158,9 @@ fn main() -> Result<()> {
     // escape responses come through stdin without echoing as characters.
     let picker = build_picker(cli.graphics.into());
 
-    let audio = AudioPlayer::new()?;
+    let shared_audio = shared_audio::open(&cli.bespoke_shm)?;
+    let shared_audio_control = shared_audio.clone();
+    let audio = AudioPlayer::new(Some(shared_audio))?;
     let video = NativeVideoBackend::new(picker.clone());
     let art = NativeAlbumArt::new(picker);
 
@@ -203,7 +211,13 @@ fn main() -> Result<()> {
     // it just stays off.
     let mut media = MediaOs::new().ok();
 
-    let res = run_loop(&mut terminal, &mut app, idx_rx, media.as_mut());
+    let res = run_loop(
+        &mut terminal,
+        &mut app,
+        idx_rx,
+        media.as_mut(),
+        Some(shared_audio_control),
+    );
     restore_terminal(&mut terminal).ok();
     app.save_session();
 
@@ -248,6 +262,28 @@ fn apply_media(cmd: MediaCommand, app: &mut App) -> Result<()> {
     Ok(())
 }
 
+fn apply_shared_audio_control(shared: &SharedAudioWriter, app: &mut App) -> Result<()> {
+    let control = shared.poll_control();
+    if let Some(should_play) = control.playback {
+        if should_play && app.audio.is_paused() {
+            app.audio.toggle_pause();
+        } else if !should_play && !app.audio.is_paused() {
+            app.audio.toggle_pause();
+        }
+    }
+
+    if control.visualizer_delta > 0 {
+        for _ in 0..control.visualizer_delta {
+            app.cycle_visualizer();
+        }
+    } else if control.visualizer_delta < 0 {
+        for _ in 0..(-control.visualizer_delta) {
+            app.cycle_visualizer_back();
+        }
+    }
+
+    Ok(())
+}
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -269,6 +305,7 @@ fn run_loop(
     app: &mut App,
     index_rx: Receiver<Vec<Track>>,
     mut media: Option<&mut MediaOs>,
+    shared_audio: Option<SharedAudioWriter>,
 ) -> Result<()> {
     let frame_dur = Duration::from_millis(33);
     let start = Instant::now();
@@ -281,6 +318,10 @@ fn run_loop(
         // Adopt the library index once the background scan reports in.
         if let Ok(tracks) = index_rx.try_recv() {
             app.set_search_index(tracks);
+        }
+
+        if let Some(shared) = shared_audio.as_ref() {
+            apply_shared_audio_control(shared, app)?;
         }
 
         // Apply any OS media-control requests (media keys, desktop widget).

--- a/crates/sparkplayer-native/src/shared_audio.rs
+++ b/crates/sparkplayer-native/src/shared_audio.rs
@@ -1,0 +1,678 @@
+const MAGIC: u32 = u32::from_le_bytes(*b"SPRK");
+const VERSION: u32 = 1;
+const OUTPUT_CHANNELS: u32 = 2;
+const DEFAULT_CAPACITY_FRAMES: u32 = 48_000 * 10;
+
+pub struct SharedAudioControl {
+    pub playback: Option<bool>,
+    pub visualizer_delta: i32,
+}
+
+#[allow(dead_code)]
+#[repr(C)]
+struct SparkAudioHeader {
+    magic: u32,
+    version: u32,
+    header_size: u32,
+    capacity_frames: u32,
+    channels: u32,
+    sample_rate: u32,
+    write_frame: u64,
+    total_frames: u64,
+    generation: u64,
+    active: u32,
+    reserved: [u32; 7],
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::ffi::c_void;
+    use std::ptr;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::{Context, Result};
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Memory::{
+        CreateFileMappingW, FILE_MAP_ALL_ACCESS, MEMORY_MAPPED_VIEW_ADDRESS, MapViewOfFile,
+        PAGE_READWRITE, UnmapViewOfFile,
+    };
+
+    use super::{DEFAULT_CAPACITY_FRAMES, MAGIC, OUTPUT_CHANNELS, SparkAudioHeader, VERSION};
+
+    pub struct SharedAudioWriter {
+        inner: Arc<Mutex<SharedAudioWriterInner>>,
+    }
+
+    struct SharedAudioWriterInner {
+        mapping: HANDLE,
+        view: *mut u8,
+        capacity_frames: usize,
+        source_channels: usize,
+        sample_rate: u32,
+        write_frame: u64,
+        generation: u64,
+        pending_frame: Vec<f32>,
+        last_transport_control: u32,
+        last_visualizer_control: u32,
+    }
+
+    unsafe impl Send for SharedAudioWriterInner {}
+
+    impl SharedAudioWriter {
+        pub fn open(name: &str) -> Result<Self> {
+            let capacity_frames = DEFAULT_CAPACITY_FRAMES as usize;
+            let header_size = std::mem::size_of::<SparkAudioHeader>();
+            let byte_len =
+                header_size + capacity_frames * OUTPUT_CHANNELS as usize * size_of::<f32>();
+            let mapping_name = normalize_windows_name(name);
+            let mut wide = mapping_name.encode_utf16().collect::<Vec<_>>();
+            wide.push(0);
+
+            let mapping = unsafe {
+                CreateFileMappingW(
+                    INVALID_HANDLE_VALUE,
+                    ptr::null(),
+                    PAGE_READWRITE,
+                    (byte_len as u64 >> 32) as u32,
+                    byte_len as u32,
+                    wide.as_ptr(),
+                )
+            };
+            if mapping.is_null() {
+                anyhow::bail!("CreateFileMappingW failed for {name}");
+            }
+
+            let view_address =
+                unsafe { MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, byte_len) };
+            let view = view_address.Value.cast::<u8>();
+            if view.is_null() {
+                unsafe {
+                    CloseHandle(mapping);
+                }
+                anyhow::bail!("MapViewOfFile failed for {name}");
+            }
+
+            let mut inner = SharedAudioWriterInner {
+                mapping,
+                view,
+                capacity_frames,
+                source_channels: 2,
+                sample_rate: 44_100,
+                write_frame: 0,
+                generation: 1,
+                pending_frame: Vec::with_capacity(8),
+                last_transport_control: 0,
+                last_visualizer_control: 0,
+            };
+            inner.initialize_header();
+
+            Ok(Self {
+                inner: Arc::new(Mutex::new(inner)),
+            })
+        }
+
+        pub fn set_format(&self, channels: u16, sample_rate: u32) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.set_format(channels, sample_rate);
+            }
+        }
+
+        pub fn push_sample(&self, sample: f32) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.push_sample(sample);
+            }
+        }
+
+        pub fn reset(&self) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.reset();
+            }
+        }
+
+        pub fn poll_control(&self) -> super::SharedAudioControl {
+            self.inner
+                .lock()
+                .map(|mut inner| inner.poll_control())
+                .unwrap_or(super::SharedAudioControl {
+                    playback: None,
+                    visualizer_delta: 0,
+                })
+        }
+    }
+
+    impl Clone for SharedAudioWriter {
+        fn clone(&self) -> Self {
+            Self {
+                inner: Arc::clone(&self.inner),
+            }
+        }
+    }
+
+
+    fn normalize_windows_name(name: &str) -> String {
+        let trimmed = name.trim();
+        if trimmed.eq_ignore_ascii_case("Local\\SparkPlayerAudio") || trimmed.eq_ignore_ascii_case("Local\\sparkplayer_audio") {
+            return "Local\\SparkPlayerAudio".to_string();
+        }
+        if trimmed.starts_with("Local\\") || trimmed.starts_with("Global\\") {
+            return trimmed.to_string();
+        }
+
+        let raw = if trimmed.is_empty() {
+            "sparkplayer_audio"
+        } else if let Some(rest) = trimmed.strip_prefix('/') {
+            rest
+        } else {
+            trimmed
+                .rsplit(['\\', '/', ':'])
+                .next()
+                .unwrap_or("sparkplayer_audio")
+        };
+
+        if raw.eq_ignore_ascii_case("SparkPlayerAudio") || raw.eq_ignore_ascii_case("sparkplayer_audio") {
+            return "Local\\SparkPlayerAudio".to_string();
+        }
+
+        let mut normalized = String::from("Local\\");
+        for ch in raw.chars() {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+                normalized.push(ch);
+            } else {
+                normalized.push('_');
+            }
+        }
+        if normalized == "Local\\" {
+            normalized.push_str("SparkPlayerAudio");
+        }
+        normalized
+    }
+    impl SharedAudioWriterInner {
+        fn header(&self) -> *mut SparkAudioHeader {
+            self.view.cast::<SparkAudioHeader>()
+        }
+
+        fn poll_control(&mut self) -> super::SharedAudioControl {
+            let header = self.header();
+            let transport_generation = unsafe { ptr::addr_of!((*header).reserved[0]).read_volatile() };
+            let transport_state = unsafe { ptr::addr_of!((*header).reserved[1]).read_volatile() };
+            let visualizer_generation = unsafe { ptr::addr_of!((*header).reserved[2]).read_volatile() };
+            let visualizer_delta = unsafe { ptr::addr_of!((*header).reserved[3]).read_volatile() as i32 };
+
+            let playback = if transport_generation != self.last_transport_control {
+                self.last_transport_control = transport_generation;
+                match transport_state {
+                    1 => Some(true),
+                    2 => Some(false),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
+            let delta = if visualizer_generation != self.last_visualizer_control {
+                self.last_visualizer_control = visualizer_generation;
+                visualizer_delta.clamp(-16, 16)
+            } else {
+                0
+            };
+
+            super::SharedAudioControl {
+                playback,
+                visualizer_delta: delta,
+            }
+        }
+        fn initialize_header(&mut self) {
+            let header = self.header();
+            unsafe {
+                ptr::write(
+                    header,
+                    SparkAudioHeader {
+                        magic: MAGIC,
+                        version: VERSION,
+                        header_size: size_of::<SparkAudioHeader>() as u32,
+                        capacity_frames: self.capacity_frames as u32,
+                        channels: OUTPUT_CHANNELS,
+                        sample_rate: self.sample_rate,
+                        write_frame: 0,
+                        total_frames: 0,
+                        generation: self.generation,
+                        active: 1,
+                        reserved: [0; 7],
+                    },
+                );
+            }
+            self.clear_audio();
+        }
+
+        fn set_format(&mut self, channels: u16, sample_rate: u32) {
+            let channels = channels.max(1) as usize;
+            let sample_rate = sample_rate.max(1);
+            if self.source_channels == channels && self.sample_rate == sample_rate {
+                return;
+            }
+            self.source_channels = channels;
+            self.sample_rate = sample_rate;
+            self.pending_frame.clear();
+            self.reset();
+        }
+
+        fn reset(&mut self) {
+            self.write_frame = 0;
+            self.generation = self.generation.wrapping_add(1).max(1);
+            self.pending_frame.clear();
+            self.clear_audio();
+            let header = self.header();
+            unsafe {
+                ptr::addr_of_mut!((*header).sample_rate).write_volatile(self.sample_rate);
+                ptr::addr_of_mut!((*header).write_frame).write_volatile(0);
+                ptr::addr_of_mut!((*header).total_frames).write_volatile(0);
+                ptr::addr_of_mut!((*header).generation).write_volatile(self.generation);
+                ptr::addr_of_mut!((*header).active).write_volatile(1);
+            }
+        }
+
+        fn clear_audio(&mut self) {
+            let sample_ptr = unsafe { self.view.add(size_of::<SparkAudioHeader>()).cast::<f32>() };
+            let sample_count = self.capacity_frames * OUTPUT_CHANNELS as usize;
+            unsafe {
+                ptr::write_bytes(sample_ptr, 0, sample_count);
+            }
+        }
+
+        fn push_sample(&mut self, sample: f32) {
+            self.pending_frame.push(sample);
+            if self.pending_frame.len() < self.source_channels {
+                return;
+            }
+
+            let (left, right) = if self.source_channels == 1 {
+                (self.pending_frame[0], self.pending_frame[0])
+            } else {
+                (self.pending_frame[0], self.pending_frame[1])
+            };
+            self.pending_frame.clear();
+            self.push_stereo_frame(left, right);
+        }
+
+        fn push_stereo_frame(&mut self, left: f32, right: f32) {
+            let frame_index = (self.write_frame as usize) % self.capacity_frames;
+            let sample_offset = frame_index * OUTPUT_CHANNELS as usize;
+            let sample_ptr = unsafe { self.view.add(size_of::<SparkAudioHeader>()).cast::<f32>() };
+            unsafe {
+                sample_ptr.add(sample_offset).write(left);
+                sample_ptr.add(sample_offset + 1).write(right);
+            }
+
+            self.write_frame = self.write_frame.wrapping_add(1);
+            let header = self.header();
+            unsafe {
+                ptr::addr_of_mut!((*header).write_frame).write_volatile(self.write_frame);
+                ptr::addr_of_mut!((*header).total_frames).write_volatile(self.write_frame);
+            }
+        }
+    }
+
+    impl Drop for SharedAudioWriterInner {
+        fn drop(&mut self) {
+            if !self.view.is_null() {
+                let header = self.header();
+                unsafe {
+                    ptr::addr_of_mut!((*header).active).write_volatile(0);
+                    UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+                        Value: self.view.cast::<c_void>(),
+                    });
+                }
+                self.view = ptr::null_mut();
+            }
+            if !self.mapping.is_null() {
+                unsafe {
+                    CloseHandle(self.mapping);
+                }
+                self.mapping = ptr::null_mut();
+            }
+        }
+    }
+
+    pub fn open(name: &str) -> Result<SharedAudioWriter> {
+        SharedAudioWriter::open(name).with_context(|| format!("opening shared audio stream {name}"))
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use std::ffi::CString;
+    use std::ptr;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::{Context, Result};
+    use libc::{
+        MAP_FAILED, MAP_SHARED, O_CREAT, O_RDWR, PROT_READ, PROT_WRITE, c_void, close, ftruncate,
+        mmap, munmap, shm_open, shm_unlink,
+    };
+
+    use super::{DEFAULT_CAPACITY_FRAMES, MAGIC, OUTPUT_CHANNELS, SparkAudioHeader, VERSION};
+
+    pub struct SharedAudioWriter {
+        inner: Arc<Mutex<SharedAudioWriterInner>>,
+    }
+
+    struct SharedAudioWriterInner {
+        fd: i32,
+        name: CString,
+        view: *mut u8,
+        byte_len: usize,
+        capacity_frames: usize,
+        source_channels: usize,
+        sample_rate: u32,
+        write_frame: u64,
+        generation: u64,
+        pending_frame: Vec<f32>,
+        last_transport_control: u32,
+        last_visualizer_control: u32,
+    }
+
+    unsafe impl Send for SharedAudioWriterInner {}
+
+    impl SharedAudioWriter {
+        pub fn open(name: &str) -> Result<Self> {
+            let name = normalize_posix_name(name)?;
+            let capacity_frames = DEFAULT_CAPACITY_FRAMES as usize;
+            let header_size = std::mem::size_of::<SparkAudioHeader>();
+            let byte_len =
+                header_size + capacity_frames * OUTPUT_CHANNELS as usize * size_of::<f32>();
+
+            unsafe {
+                shm_unlink(name.as_ptr());
+            }
+            let fd = unsafe { shm_open(name.as_ptr(), O_CREAT | O_RDWR, 0o600) };
+            if fd < 0 {
+                anyhow::bail!("shm_open failed for {}", name.to_string_lossy());
+            }
+
+            if unsafe { ftruncate(fd, byte_len as libc::off_t) } != 0 {
+                unsafe {
+                    close(fd);
+                    shm_unlink(name.as_ptr());
+                }
+                anyhow::bail!("ftruncate failed for {}", name.to_string_lossy());
+            }
+
+            let view = unsafe {
+                mmap(
+                    ptr::null_mut(),
+                    byte_len,
+                    PROT_READ | PROT_WRITE,
+                    MAP_SHARED,
+                    fd,
+                    0,
+                )
+            };
+            if view == MAP_FAILED {
+                unsafe {
+                    close(fd);
+                    shm_unlink(name.as_ptr());
+                }
+                anyhow::bail!("mmap failed for {}", name.to_string_lossy());
+            }
+
+            let mut inner = SharedAudioWriterInner {
+                fd,
+                name,
+                view: view.cast::<u8>(),
+                byte_len,
+                capacity_frames,
+                source_channels: 2,
+                sample_rate: 44_100,
+                write_frame: 0,
+                generation: 1,
+                pending_frame: Vec::with_capacity(8),
+                last_transport_control: 0,
+                last_visualizer_control: 0,
+            };
+            inner.initialize_header();
+
+            Ok(Self {
+                inner: Arc::new(Mutex::new(inner)),
+            })
+        }
+
+        pub fn set_format(&self, channels: u16, sample_rate: u32) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.set_format(channels, sample_rate);
+            }
+        }
+
+        pub fn push_sample(&self, sample: f32) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.push_sample(sample);
+            }
+        }
+
+        pub fn reset(&self) {
+            if let Ok(mut inner) = self.inner.lock() {
+                inner.reset();
+            }
+        }
+
+        pub fn poll_control(&self) -> super::SharedAudioControl {
+            self.inner
+                .lock()
+                .map(|mut inner| inner.poll_control())
+                .unwrap_or(super::SharedAudioControl {
+                    playback: None,
+                    visualizer_delta: 0,
+                })
+        }
+    }
+
+    impl Clone for SharedAudioWriter {
+        fn clone(&self) -> Self {
+            Self {
+                inner: Arc::clone(&self.inner),
+            }
+        }
+    }
+
+    fn normalize_posix_name(name: &str) -> Result<CString> {
+        let trimmed = name.trim();
+        let raw = if trimmed.is_empty() {
+            "sparkplayer_audio"
+        } else if let Some(rest) = trimmed.strip_prefix('/') {
+            rest
+        } else {
+            trimmed
+                .rsplit(['\\', '/', ':'])
+                .next()
+                .unwrap_or("sparkplayer_audio")
+        };
+        let mut normalized = String::with_capacity(raw.len() + 1);
+        normalized.push('/');
+        for ch in raw.chars() {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+                normalized.push(ch);
+            } else {
+                normalized.push('_');
+            }
+        }
+        if normalized.len() == 1 {
+            normalized.push_str("SparkPlayerAudio");
+        }
+        CString::new(normalized).context("shared audio stream name contains a NUL byte")
+    }
+
+    impl SharedAudioWriterInner {
+        fn header(&self) -> *mut SparkAudioHeader {
+            self.view.cast::<SparkAudioHeader>()
+        }
+
+        fn poll_control(&mut self) -> super::SharedAudioControl {
+            let header = self.header();
+            let transport_generation = unsafe { ptr::addr_of!((*header).reserved[0]).read_volatile() };
+            let transport_state = unsafe { ptr::addr_of!((*header).reserved[1]).read_volatile() };
+            let visualizer_generation = unsafe { ptr::addr_of!((*header).reserved[2]).read_volatile() };
+            let visualizer_delta = unsafe { ptr::addr_of!((*header).reserved[3]).read_volatile() as i32 };
+
+            let playback = if transport_generation != self.last_transport_control {
+                self.last_transport_control = transport_generation;
+                match transport_state {
+                    1 => Some(true),
+                    2 => Some(false),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
+            let delta = if visualizer_generation != self.last_visualizer_control {
+                self.last_visualizer_control = visualizer_generation;
+                visualizer_delta.clamp(-16, 16)
+            } else {
+                0
+            };
+
+            super::SharedAudioControl {
+                playback,
+                visualizer_delta: delta,
+            }
+        }
+        fn initialize_header(&mut self) {
+            let header = self.header();
+            unsafe {
+                ptr::write(
+                    header,
+                    SparkAudioHeader {
+                        magic: MAGIC,
+                        version: VERSION,
+                        header_size: size_of::<SparkAudioHeader>() as u32,
+                        capacity_frames: self.capacity_frames as u32,
+                        channels: OUTPUT_CHANNELS,
+                        sample_rate: self.sample_rate,
+                        write_frame: 0,
+                        total_frames: 0,
+                        generation: self.generation,
+                        active: 1,
+                        reserved: [0; 7],
+                    },
+                );
+            }
+            self.clear_audio();
+        }
+
+        fn set_format(&mut self, channels: u16, sample_rate: u32) {
+            let channels = channels.max(1) as usize;
+            let sample_rate = sample_rate.max(1);
+            if self.source_channels == channels && self.sample_rate == sample_rate {
+                return;
+            }
+            self.source_channels = channels;
+            self.sample_rate = sample_rate;
+            self.pending_frame.clear();
+            self.reset();
+        }
+
+        fn reset(&mut self) {
+            self.write_frame = 0;
+            self.generation = self.generation.wrapping_add(1).max(1);
+            self.pending_frame.clear();
+            self.clear_audio();
+            let header = self.header();
+            unsafe {
+                ptr::addr_of_mut!((*header).sample_rate).write_volatile(self.sample_rate);
+                ptr::addr_of_mut!((*header).write_frame).write_volatile(0);
+                ptr::addr_of_mut!((*header).total_frames).write_volatile(0);
+                ptr::addr_of_mut!((*header).generation).write_volatile(self.generation);
+                ptr::addr_of_mut!((*header).active).write_volatile(1);
+            }
+        }
+
+        fn clear_audio(&mut self) {
+            let sample_ptr = unsafe { self.view.add(size_of::<SparkAudioHeader>()).cast::<f32>() };
+            let sample_count = self.capacity_frames * OUTPUT_CHANNELS as usize;
+            unsafe {
+                ptr::write_bytes(sample_ptr, 0, sample_count);
+            }
+        }
+
+        fn push_sample(&mut self, sample: f32) {
+            self.pending_frame.push(sample);
+            if self.pending_frame.len() < self.source_channels {
+                return;
+            }
+
+            let (left, right) = if self.source_channels == 1 {
+                (self.pending_frame[0], self.pending_frame[0])
+            } else {
+                (self.pending_frame[0], self.pending_frame[1])
+            };
+            self.pending_frame.clear();
+            self.push_stereo_frame(left, right);
+        }
+
+        fn push_stereo_frame(&mut self, left: f32, right: f32) {
+            let frame_index = (self.write_frame as usize) % self.capacity_frames;
+            let sample_offset = frame_index * OUTPUT_CHANNELS as usize;
+            let sample_ptr = unsafe { self.view.add(size_of::<SparkAudioHeader>()).cast::<f32>() };
+            unsafe {
+                sample_ptr.add(sample_offset).write(left);
+                sample_ptr.add(sample_offset + 1).write(right);
+            }
+
+            self.write_frame = self.write_frame.wrapping_add(1);
+            let header = self.header();
+            unsafe {
+                ptr::addr_of_mut!((*header).write_frame).write_volatile(self.write_frame);
+                ptr::addr_of_mut!((*header).total_frames).write_volatile(self.write_frame);
+            }
+        }
+    }
+
+    impl Drop for SharedAudioWriterInner {
+        fn drop(&mut self) {
+            if !self.view.is_null() {
+                let header = self.header();
+                unsafe {
+                    ptr::addr_of_mut!((*header).active).write_volatile(0);
+                    munmap(self.view.cast::<c_void>(), self.byte_len);
+                }
+                self.view = ptr::null_mut();
+            }
+            if self.fd >= 0 {
+                unsafe {
+                    close(self.fd);
+                    shm_unlink(self.name.as_ptr());
+                }
+                self.fd = -1;
+            }
+        }
+    }
+
+    pub fn open(name: &str) -> Result<SharedAudioWriter> {
+        SharedAudioWriter::open(name).with_context(|| format!("opening shared audio stream {name}"))
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+mod imp {
+    use anyhow::Result;
+
+    #[derive(Clone)]
+    pub struct SharedAudioWriter;
+
+    impl SharedAudioWriter {
+        pub fn set_format(&self, _channels: u16, _sample_rate: u32) {}
+        pub fn push_sample(&self, _sample: f32) {}
+        pub fn reset(&self) {}
+        pub fn poll_control(&self) -> super::SharedAudioControl {
+            super::SharedAudioControl {
+                playback: None,
+                visualizer_delta: 0,
+            }
+        }
+    }
+
+    pub fn open(_name: &str) -> Result<SharedAudioWriter> {
+        Ok(SharedAudioWriter)
+    }
+}
+
+pub use imp::{SharedAudioWriter, open};


### PR DESCRIPTION
> The second commit has several issues. It can fail hard on startup if no shm is found, it's always on with no opt-out, there's data loss if multiple instances are started, it takes a Mutex on every sample on the playback thread which is expensive, there's no synchronization of the readers (there's a "generation" field but it's unused, perhaps that was anticipated but not finished?), you enable Win32_Security and Win32_System_SystemServices features but never use them, libc is added as an unconditional dependency, there are no tests and no documentation of any kind.


Implemented the cleanup pass for the SparkPlayer shared-memory bridge.
What changed:
- --bespoke-shm is now opt-in. Omit it and SparkPlayer does no SHM work.
- --bespoke-shm with no value still uses /sparkplayer_audio.
- SHM open failures now warn and continue instead of aborting startup.
- Multiple SparkPlayer instances using the same SHM name no longer wipe/replace each other; the later one disables its bridge.
- Removed the per-sample Mutex; audio now packs frames in TapSource and writes stereo frames through atomics/raw mapped memory.
- generation is now documented as the reader synchronization guard for resets/format changes.
- Removed unused Win32_System_SystemServices; kept Win32_Security because CreateFileMappingW’s signature requires SECURITY_ATTRIBUTES.
- Moved libc to Unix-only dependencies.
- Added focused tests for mono/stereo/multichannel frame packing.
- Added README docs for --bespoke-shm and the ring-buffer protocol.

I am using Codex for this and I still have a working integration on my machine.
https://github.com/davehorner/BespokeSynth_gen is where I will have the bespoke side of things if you want to try it out.  SparkPlayer is available as a synth, and must be added to a running Bespoke while sparkplayer is running with the --bespoke-shm option supplied.  If you are interested in this contribution, I can work on it being a bit more resilient to closing and starting sparkplayer, but I mostly had my fun with it when I saw it working on my win11 and macos.

This change lets you connect bespoke to sparkplayer so that the visualizations update and display along with sparkplayer.

<img width="813" height="455" alt="image" src="https://github.com/user-attachments/assets/585896a3-b01c-495f-ad00-3a733251b326" />
it has two buttons that change the viz of the running sparkplayer.